### PR TITLE
UPNP socket leak

### DIFF
--- a/upnp.go
+++ b/upnp.go
@@ -104,6 +104,7 @@ func upnpResponder(hostAddr string, endpoint string) {
 				log.Fatal("[UPNP] execute template failed:", err)
 			}
 			c.Write(b.Bytes())
+			c.Close()
 		}
 	}
 }


### PR DESCRIPTION
The UDP socket doesn't auto-close at the end of the for loop and so
we end up leaking file descriptions.  Always Close() the socket after
sending our response